### PR TITLE
A few small fixes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,8 +7,10 @@
     <meta name="description" content="A minimalist coding environment. Control 16x16 points with a single JavaScript function.">
     <link rel="stylesheet" href="style.styl" inline="inline" />
 
-    <link rel="icon" type="image/x-icon" href="./assets/favicon.png" />
+    <link rel="icon" type="image/png" href="./assets/favicon.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="./assets/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="./assets/android-chrome-512x512.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="./assets/android-chrome-192x192.png">
     <link rel="icon" type="image/png" sizes="32x32" href="./assets/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="./assets/favicon-16x16.png">
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const count = 16;
 const size = 16;
 const spacing = 1;
-const width = count * (size + spacing);
+const width = count * (size + spacing) - spacing;
 
 import examples from './examples.json';
 

--- a/src/style.styl
+++ b/src/style.styl
@@ -29,7 +29,7 @@ label, input
 
 #editor
   display: block
-  width: 272px
+  width: 271px
   line-height: 1.15em
   #input
     background: none


### PR DESCRIPTION
I noticed these while was merging some of the recent changes into [tixyz](http://github.com/doersino/tixyz):

* The high-res favicons `src/assets/android-chrome-192x192.png` and `src/assets/android-chrome-512x512.png` weren't actually referenced in the code. This pull request references them in the same manner as the smaller favicons.
* The MIME type of the standard favicon `src/assets/favicon.png` was given as `image/x-icon`, not `image/png`. I don't think this will trip any modern browser up, but it's fixed now.
* The `#output` canvas was too wide – it included 1 px of spacing to the right of each column, but there's no need for spacing next to the right-most column.