### PR TITLE
Feature: load code from a GitHub Gist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "tixy",
-  "version": "1.0.0",
+  "name": "tixy-land",
+  "version": "1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1824,6 +1824,11 @@
       "requires": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "strip-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
+      "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw=="
     },
     "stylehacks": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "gif.js.optimized": "^1.0.1",
-    "pureimage": "^0.2.5"
+    "pureimage": "^0.2.5",
+    "strip-comments": "^2.0.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,12 @@ function readURL() {
   }
 }
 
+function submitCode(code) {
+  const url = new URL(document.location);
+  url.searchParams.set('code', code);
+  history.replaceState(null, code, url);
+}
+
 readURL();
 
 function checkLength() {
@@ -77,9 +83,7 @@ input.addEventListener('blur', function () {
 
 editor.addEventListener('submit', (event) => {
   event.preventDefault();
-  const url = new URL(document.location);
-  url.searchParams.set('code', code);
-  history.replaceState(null, code, url);
+  submitCode(code)
 });
 
 function render() {


### PR DESCRIPTION
I've really been enjoying myself with tixy.

Your [tweet with the commented source code][1] of the game of life (in 88 bytes) gave me an idea...  

What if it was possible to place JS code in a Github Gist and then load that Gist in tixy?

This merge-request does just that!

It can be seen working at https://contrib.pother.ca/tixy/, for instance: https://contrib.pother.ca/tixy/?gist=c37b144721a707d6115647ad0889fea3 (for [this gist][2]).

I'm not sure if adding this code to the main flow is desirable or if it would be better to add it in a sub-directory, similar to how `gallery`, `gif`, and `image` now work.

In either case, if this is functionality you'd enjoy adding, I'm willing to make whatever changes you like.

If not, I could always create a separate [gist-to-tixy service][3]... :grin: 

[1]: https://twitter.com/aemkei/status/1333529631434153985
[2]: https://gist.github.com/Potherca/c37b144721a707d6115647ad0889fea3
[3]: https://gist-to-tixy.potherca.workers.dev/?gist=your-gist-id-here